### PR TITLE
Add getConsignment GQL query to facilitate error handling

### DIFF
--- a/src/main/graphql/GetConsignment.graphql
+++ b/src/main/graphql/GetConsignment.graphql
@@ -1,7 +1,7 @@
- query getConsignment($consignmentid: Long) {
-   getConsignment(consignmentid: $consignmentId) {
-     userid
-       seriesid
-   }
- }
+query getConsignment($consignmentid: Long) {
+    getConsignment(consignmentid: $consignmentId) {
+        userid
+        seriesid
+    }
+}
  

--- a/src/main/graphql/GetConsignment.graphql
+++ b/src/main/graphql/GetConsignment.graphql
@@ -1,0 +1,7 @@
+ query getConsignment($consignmentid: Long) {
+   getConsignment(consignmentid: $consignmentId) {
+     userid
+       seriesid
+   }
+ }
+ 


### PR DESCRIPTION
getConsignment query added to help handle errors appropriately and only show transfer agreement page if a consignment associated with the user has already been created.
If not then we will show a 404 page.