### PR TITLE
Remove userid parameter from consignment creation

### DIFF
--- a/src/main/graphql/AddConsignment.graphql
+++ b/src/main/graphql/AddConsignment.graphql
@@ -2,6 +2,5 @@ mutation addConsignment($addConsignmentInput: AddConsignmentInput!) {
     addConsignment(addConsignmentInput: $addConsignmentInput) {
         consignmentid
         seriesid
-        userid
     }
 }


### PR DESCRIPTION
The API now takes the user ID from the auth token, so this parameter is no longer compulsory.