### PR TITLE
Make the series body a compulsory argument

### DIFF
--- a/src/main/graphql/GetSeries.graphql
+++ b/src/main/graphql/GetSeries.graphql
@@ -1,4 +1,4 @@
-query getSeries($body: String) {
+query getSeries($body: String!) {
     getSeries(body: $body) {
         seriesid,
         bodyid,


### PR DESCRIPTION
The frontend is the only client which uses this endpoint, and it always provides a body.

The optional body caused a bug where setting the body to null would return all series rather than returning an error.