### PR TITLE
Publish compiled javascript

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
                         dir("ts"){
                             sh 'npm ci'
                             sh 'npm run codegen'
+			    sh 'npm run build'
                             sh 'git config --global user.email tna-digital-archiving-jenkins@nationalarchives.gov.uk'
                             sh 'git config --global user.name tna-digital-archiving-jenkins'
                             sshagent(['github-jenkins']) {

--- a/ts/codegen.yml
+++ b/ts/codegen.yml
@@ -5,10 +5,10 @@ config:
   scalars:
     Long: number
 generates:
-  index.d.ts:
+  src/index.d.ts:
     plugins:
       - typescript-graphql-files-modules
-  index.ts:
+  src/index.ts:
     plugins:
       - "typescript"
       - "typescript-operations"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "",
   "main": "index.ts",
   "scripts": {
@@ -17,6 +17,11 @@
   "bugs": {
     "url": "https://github.com/nationalarchives/tdr-generated-graphql/issues"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "package.json"
+  ],
   "homepage": "https://github.com/nationalarchives/tdr-generated-graphql#readme",
   "devDependencies": {
     "ts-loader": "^6.2.2",

--- a/ts/webpack.config.js
+++ b/ts/webpack.config.js
@@ -18,8 +18,8 @@ module.exports = {
   },
   plugins: [new DtsBundlePlugin()],
   output: {
-    filename: "main.js",
-    path: path.resolve(__dirname, "../public/javascripts")
+    filename: "index.js",
+    path: path.resolve(__dirname, ".")
   }
 };
 
@@ -31,7 +31,7 @@ DtsBundlePlugin.prototype.apply = function(compiler) {
     dts.bundle({
       name: "tdr",
       main: "src/index.d.ts",
-      out: "../dist/index.d.ts",
+      out: "../index.d.ts",
       removeSource: true,
       outputAsModuleFolder: true // to use npm in-package typings
     });


### PR DESCRIPTION
This is mostly just fixing the paths of all of the outputs so that I can run webpack against it to generate the js file. This is then used within the frontend. I did originally publish the unmodified typescript file but the problem with this is that the typescript compiler in the front end isn't expecting to have to compile files from libraries and so it was failing.