### PR TITLE
Two queries for the file format processing

### DIFF
--- a/src/main/graphql/AddFFIDMetadata.graphql
+++ b/src/main/graphql/AddFFIDMetadata.graphql
@@ -1,0 +1,5 @@
+mutation addFFIDMetadata($addFFIDMetadataInput: FFIDMetadataInput!) {
+    addFFIDMetadata(addFFIDMetadataInput: $addFFIDMetadataInput) {
+        fileId
+    }
+}

--- a/src/main/graphql/GetOriginalPath.graphql
+++ b/src/main/graphql/GetOriginalPath.graphql
@@ -1,0 +1,5 @@
+query getOriginalPath($fileId: UUID!) {
+    getClientFileMetadata(fileId: $fileId) {
+        originalPath
+    }
+}


### PR DESCRIPTION
One is to add the FFID metadata and the other one is to get the original
path so this can be fed into Siegfried so we get a sensible response.