### PR TITLE
Add query for file check progress

### DIFF
--- a/src/main/graphql/GetConsignment.graphql
+++ b/src/main/graphql/GetConsignment.graphql
@@ -2,5 +2,11 @@ query getConsignment($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
         userid
         seriesid
+        totalFiles
+        fileCheckProgress {
+            antivirusProgress {
+                processedFiles
+            }
+        }
     }
 }

--- a/src/main/graphql/GetConsignment.graphql
+++ b/src/main/graphql/GetConsignment.graphql
@@ -2,11 +2,5 @@ query getConsignment($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
         userid
         seriesid
-        totalFiles
-        fileCheckProgress {
-            antivirusProgress {
-                processedFiles
-            }
-        }
     }
 }

--- a/src/main/graphql/GetFileCheckProgress.graphql
+++ b/src/main/graphql/GetFileCheckProgress.graphql
@@ -1,0 +1,10 @@
+query getFileCheckProgress($consignmentId: UUID!) {
+    getConsignment(consignmentid: $consignmentId) {
+        totalFiles
+        fileCheckProgress {
+            antivirusProgress {
+                processedFiles
+            }
+        }
+    }
+}

--- a/src/main/graphql/GetFileCheckProgress.graphql
+++ b/src/main/graphql/GetFileCheckProgress.graphql
@@ -1,9 +1,9 @@
 query getFileCheckProgress($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
         totalFiles
-        fileCheckProgress {
+        fileChecks {
             antivirusProgress {
-                processedFiles
+                filesProcessed
             }
         }
     }


### PR DESCRIPTION
This is in line with changes made on the [consignment API](https://github.com/nationalarchives/tdr-consignment-api/pull/57) to allow queries to get information about metadata processing of files within a consignment. This will allow us to use API queries to show TDR users the progress of file processing in the front-end project.