### PR TITLE
Manually bump npm and sbt version numbers

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.56-SNAPSHOT"
+version in ThisBuild := "0.0.57-SNAPSHOT"


### PR DESCRIPTION
The Jenkins build for incrementing version numbers is still broken.