### PR TITLE
Remove antivirus "value" field

### DIFF
--- a/src/main/graphql/AddAntivirusMetadata.graphql
+++ b/src/main/graphql/AddAntivirusMetadata.graphql
@@ -2,7 +2,6 @@ mutation AddAntivirusMetadata($input: AddAntivirusMetadataInput!) {
     addAntivirusMetadata(addAntivirusMetadataInput: $input) {
         fileId
         software
-        value
         softwareVersion
         databaseVersion
         result


### PR DESCRIPTION
This field is optional in the database and the consignment API, and it is not used. The result of the antivirus scan is stored in the `result` field.