### PR TITLE
Add FFIDMetadata file processing to existing fileCheck query

### DIFF
--- a/src/main/graphql/GetFileCheckProgress.graphql
+++ b/src/main/graphql/GetFileCheckProgress.graphql
@@ -8,7 +8,9 @@ query getFileCheckProgress($consignmentId: UUID!) {
             checksumProgress {
                 filesProcessed
             }
-
+            ffidProgress {
+                filesProcessed
+            }
         }
     }
 }


### PR DESCRIPTION
This was tested with my local copy of the consignment API and works as expected.