### PR TITLE
Remove datetime from mutation response.

### DIFF
--- a/src/main/graphql/AddClientFileMetadata.graphql
+++ b/src/main/graphql/AddClientFileMetadata.graphql
@@ -5,6 +5,6 @@ mutation AddClientFileMetadata($input: [AddClientFileMetadataInput!]!) {
         checksumType
         lastModified
         fileSize
-        datetime
     }
 }
+


### PR DESCRIPTION
This field isn't used by the front end and it doesn't make sense in terms of how we're storing the data anyway so it can be removed. Once it's gone, we can remove it from the api.
