### PR TITLE
Remove hard coded version from task definition.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
           agent {
             ecs {
               inheritFrom "base"
-              taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
+              taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}"
             }
           }
           stages {


### PR DESCRIPTION
It's not needed, if it's not used then it gets the latest which is what
we want.
