### PR TITLE
Update GraphQl queries to reflect Consignment Metadata

### DIFF
--- a/src/main/graphql/AddTransferAgreement.graphql
+++ b/src/main/graphql/AddTransferAgreement.graphql
@@ -6,5 +6,6 @@ mutation AddTransferAgreement($input: AddTransferAgreementInput!){
         allEnglish
         appraisalSelectionSignedOff
         sensitivityReviewSignedOff
+        initialOpenRecords
     }
 }

--- a/src/main/graphql/GetTransferAgreement.graphql
+++ b/src/main/graphql/GetTransferAgreement.graphql
@@ -7,5 +7,6 @@ query getTransferAgreement($consignmentId: UUID!) {
     appraisalSelectionSignedOff
     sensitivityReviewSignedOff
     isAgreementComplete
+    initialOpenRecords
   }
 }


### PR DESCRIPTION
Transfer Agreement data saved to Consignment Metadata table with additional value 'initialOpenRecord'