### PR TITLE
Add consignment reference to consignment summary query

### DIFF
--- a/src/main/graphql/GetConsignmentSummary.graphql
+++ b/src/main/graphql/GetConsignmentSummary.graphql
@@ -6,6 +6,7 @@ query getConsignmentSummary($consignmentId: UUID!) {
         transferringBody {
             name
         }
-        totalFiles
+        totalFiles,
+        consignmentReference
     }
 }


### PR DESCRIPTION
This will allow us to display the consignment reference to the user within the transfer summary page.