### PR TITLE
Add getConsignmentStatus query so we can query consignment status on upload

### DIFF
--- a/src/main/graphql/GetConsignmentStatus.graphql
+++ b/src/main/graphql/GetConsignmentStatus.graphql
@@ -1,0 +1,10 @@
+query getConsignmentStatus($consignmentId: UUID!) {
+    getConsignment(consignmentid: $consignmentId) {
+        series {
+            code
+        },
+        currentStatus {
+            upload
+        }
+    }
+}

--- a/src/main/graphql/GetConsignmentStatus.graphql
+++ b/src/main/graphql/GetConsignmentStatus.graphql
@@ -1,8 +1,5 @@
 query getConsignmentStatus($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
-        series {
-            code
-        },
         currentStatus {
             upload
         }


### PR DESCRIPTION
This will allow us to show the user an error should they have already begun an upload for a given consignment ID, thus stopping consignments from breaking file checks due to having more than one upload.