### PR TITLE
Add parent folder to file status query

### DIFF
--- a/src/main/graphql/GetFileCheckProgress.graphql
+++ b/src/main/graphql/GetFileCheckProgress.graphql
@@ -1,6 +1,7 @@
 query getFileCheckProgress($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
         allChecksSucceeded
+        parentFolder
         totalFiles
         fileChecks {
             antivirusProgress {


### PR DESCRIPTION
In the frontend, there is an route which displays the file check success page. This needs the parent folder and total files which are currently in another query.

For this route, we need to check if the file checks have succeeded and re-route to the failure page if they haven't so we need parent folder, totalFiles and allChecksSucceeded in the same query. It makes sense to add parentFolder to this one.
