### PR TITLE
Split file check progress queries

### DIFF
--- a/src/main/graphql/GetFileCheckProgressSummary.graphql
+++ b/src/main/graphql/GetFileCheckProgressSummary.graphql
@@ -1,0 +1,16 @@
+query getFileCheckProgressSummary($consignmentId: UUID!) {
+    getConsignment(consignmentid: $consignmentId) {
+        totalFiles
+        fileChecks {
+            antivirusProgress {
+                filesProcessed
+            }
+            checksumProgress {
+                filesProcessed
+            }
+            ffidProgress {
+                filesProcessed
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a new query called `GetFileCheckProgressSummary` which is a reduced version of `GetFileCheckProgress`.

This will let us switch to the shorter version in the JavaScript code, so that it does not have to fetch the folder name and file check results every time it fetches the progress, which is every few seconds.