### PR TITLE
Add new queries to split file data

### DIFF
--- a/src/main/graphql/AddFilesAndMetadata.graphql
+++ b/src/main/graphql/AddFilesAndMetadata.graphql
@@ -1,6 +1,6 @@
 mutation AddFilesAndMetadata($input: AddFileAndMetadataInput!) {
     addFilesAndMetadata(addFilesAndMetadataInput: $input) {
         fileId
-        sequenceNumber
+        matchId
     }
 }

--- a/src/main/graphql/AddFilesAndMetadata.graphql
+++ b/src/main/graphql/AddFilesAndMetadata.graphql
@@ -1,0 +1,6 @@
+mutation AddFilesAndMetadata($input: AddFileAndMetadataInput!) {
+    addFilesAndMetadata(addFilesAndMetadataInput: $input) {
+        fileId
+        sequenceNumber
+    }
+}

--- a/src/main/graphql/StartUpload.graphql
+++ b/src/main/graphql/StartUpload.graphql
@@ -1,0 +1,3 @@
+mutation StartUpload($input: StartUploadInput!) {
+    startUpload(startUploadInput: $input)
+}

--- a/src/main/graphql/StartUpload.graphql
+++ b/src/main/graphql/StartUpload.graphql
@@ -1,4 +1,3 @@
 mutation StartUpload($input: StartUploadInput!) {
     startUpload(startUploadInput: $input)
 }
-

--- a/src/main/graphql/StartUpload.graphql
+++ b/src/main/graphql/StartUpload.graphql
@@ -1,3 +1,4 @@
 mutation StartUpload($input: StartUploadInput!) {
     startUpload(startUploadInput: $input)
 }
+


### PR DESCRIPTION
StartUpload adds the parent folder and sets the consignment status to
upload in progress.

AddFilesAndMetadata adds a group of files and the client and static
metadata and returns the file ids.
