### PR TITLE
Replace task definition name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
           agent {
             ecs {
               inheritFrom "base"
-              taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}"
+              taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
             }
           }
           stages {


### PR DESCRIPTION
The task name was changed a while ago to sbtwithpostgres.

The image hasn't been updated since then so we've not had any problems
but it has now so we need to change it to the image that's being managed
in terraform.

~
