### PR TITLE
Manually bump npm version

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nationalarchives/tdr-generated-graphql",
-      "version": "1.0.99",
+      "version": "1.0.100",
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "^2.1.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "description": "",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Previous build failed after new version was published to npm

No generated version bump branch was generated because of failure