### PR TITLE
Add instruction on how to name queries/mutations and file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ These classes are used by other TDR repositories to communicate with the consign
 
 ### Building locally
 1. Add a new query file to `src/main/graphql`:
-2. Download the latest [graphql schema file](https://raw.githubusercontent.com/nationalarchives/tdr-consignment-api/master/schema.graphql) into the `src/main/resources` directory
-3. Run the following commands to allow you to check that your changes work locally before submitting them:
+   * The file name should be in Pascal case e.g. FooBarBaz
+   * The query/mutation name should be in Camel case e.g. fooBarBaz
+3. Download the latest [graphql schema file](https://raw.githubusercontent.com/nationalarchives/tdr-consignment-api/master/schema.graphql) into the `src/main/resources` directory
+4. Run the following commands to allow you to check that your changes work locally before submitting them:
 #### Scala version
   * `sbt package publishLocal`
 


### PR DESCRIPTION
The reason why this has been added is because if the query is in Pascal case (like the file name),
when it comes using the generated GraphQL, any code using the Scala library at least (e.g. the frontend),
will get slightly confused as to the return type because the query/mutation 'object' would have two
'objects' within it with the same name e.g.

```
object AddFinalTransferConfirmation extends scala.AnyRef {
  object AddFinalTransferConfirmation extends scala.AnyRef with graphql.codegen.GraphQLQuery {
    val document : sangria.ast.Document = { /* compiled code */ }
    case class Variables(val input : graphql.codegen.types.AddFinalTransferConfirmationInput) extends scala.AnyRef with scala.Product with scala.Serializable {
    }
    object Variables extends scala.AnyRef with java.io.Serializable {
      implicit val jsonEncoder : io.circe.Encoder[AddFinalTransferConfirmation.Variables] = { /* compiled code */ }
    }
    case class Data(val addFinalTransferConfirmation : AddFinalTransferConfirmation.AddFinalTransferConfirmation) extends scala.AnyRef with scala.Product with scala.Serializable {
    }
    object Data extends scala.AnyRef with java.io.Serializable {
      implicit val jsonDecoder : io.circe.Decoder[AddFinalTransferConfirmation.Data] = { /* compiled code */ }
    }
    case class AddFinalTransferConfirmation(val consignmentId : java.util.UUID, val finalOpenRecordsConfirmed : scala.Boolean, val legalOwnershipTransferConfirmed : scala.Boolean) extends scala.AnyRef with scala.Product with scala.Serializable {
    }
    object AddFinalTransferConfirmation extends scala.AnyRef with java.io.Serializable {
      implicit val jsonDecoder : io.circe.Decoder[AddFinalTransferConfirmation.AddFinalTransferConfirmation] = { /* compiled code */ }
      implicit val jsonEncoder : io.circe.Encoder[AddFinalTransferConfirmation.AddFinalTransferConfirmation] = { /* compiled code */ }
    }
  }
}
```

References to `AddFinalTransferConfirmation.AddFinalTransferConfirmation` are ambiguous, it could be referring to the most outer 'object' or the inner one.