### PR TITLE
Add getConsignmentType query

### DIFF
--- a/src/main/graphql/GetConsignmentType.graphql
+++ b/src/main/graphql/GetConsignmentType.graphql
@@ -1,0 +1,5 @@
+query getConsignmentType($consignmentId: UUID!) {
+  getConsignment(consignmentid: $consignmentId) {
+    consignmentType
+  }
+}


### PR DESCRIPTION
The front end needs to be able to get the consignment type to determine which urls can be seen by a user. The only current query which gets it is for the export and there's a lot of data in that query that we don't need so I've made a new one.
