### PR TITLE
Publish to sonatype

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,16 @@
+git config --global user.email digitalpreservation@nationalarchives.gov.uk
+git config --global user.name tna-digital-archiving-jenkins
+git checkout -b $BRANCH_NAME
+git push -u origin $BRANCH_NAME
+mkdir -p src/main/resources
+wget -O src/main/resources/schema.graphql https://raw.githubusercontent.com/nationalarchives/tdr-consignment-api/master/schema.graphql
+cd ts
+npm ci
+npm run codegen
+npm run build
+npm version patch
+git add package.json package-lock.json
+git commit -m 'Update npm version'
+npm publish --access public
+cd ..
+sbt 'release with-defaults'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Deploy if not a version bump PR
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    if: ${{ !startsWith( github.event.commits[0].message, 'Version Bump from build number') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: gh workflow run deploy.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,8 @@ jobs:
               head: '${{ env.BRANCH_NAME }}',
               base: 'master'
             });
+      - name: Send success message
+        uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        with:
+          message: ":white_check_mark: Generated graphql has been published"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: TDR Deploy Generated Graphql
+on:
+  workflow_dispatch:
+env:
+  RUN_NUMBER: ${{ github.run_id }}${{ github.run_attempt }}
+  BRANCH_NAME: version-bump-${{ github.run_id }}${{ github.run_attempt }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - run: |
+          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          ./.github/scripts/deploy.sh
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'Version Bump from build number ${{ env.RUN_NUMBER }}',
+              owner,
+              repo,
+              head: '${{ env.BRANCH_NAME }}',
+              base: 'master'
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: TDR Run Graphql Schema Check
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+      - release-*
+jobs:
+  test:
+    runs-on:  ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
+      - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        if: failure()
+        with:
+          message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Check schema
+        run: |
+          mkdir -p src/main/resources/
+          wget -O src/main/resources/schema.graphql https://raw.githubusercontent.com/nationalarchives/tdr-consignment-api/master/schema.graphql
+          sbt graphqlCodegen

--- a/build.sbt
+++ b/build.sbt
@@ -1,40 +1,50 @@
 import Dependencies._
 import sbt.url
+import ReleaseTransformations._
 
-ThisBuild / version := (version in ThisBuild).value
 ThisBuild / organization := "uk.gov.nationalarchives"
 ThisBuild / organizationName := "National Archives"
 
 scalaVersion := "2.13.3"
 
-ThisBuild / scmInfo := Some(
+scmInfo := Some(
   ScmInfo(
     url("https://github.com/nationalarchives/tdr-generated-graphql"),
     "git@github.com:nationalarchives/tdr-generated-graphql.git"
   )
 )
-ThisBuild / developers := List(
+
+developers := List(
   Developer(
     id    = "SP",
     name  = "Sam Palmer",
     email = "sam.palmer@nationalarchives.gov.uk",
-    url   = url("http://tdr-transfer-integration.nationalarchives.gov.uk")
+    url   = url("https://github.com/nationalarchives/tdr-generated-grapqhl")
   )
 )
 
-ThisBuild / description := "Classes to be used by the graphql client to communicate with the TDR graphql API"
-ThisBuild / licenses := List("MIT" -> new URL("https://choosealicense.com/licenses/mit/"))
-ThisBuild / homepage := Some(url("https://github.com/nationalarchives/tdr-consignment-api-data"))
+description := "Classes to be used by the graphql client to communicate with the TDR graphql API"
+licenses := List("MIT" -> new URL("https://choosealicense.com/licenses/mit/"))
+homepage := Some(url("https://github.com/nationalarchives/tdr-generated-grapqhl"))
 
-s3acl := None
-s3sse := true
-ThisBuild / publishMavenStyle := true 
+useGpgPinentry := true
+publishTo := sonatypePublishToBundle.value
+publishMavenStyle := true
 
-ThisBuild / publishTo := {
-  val prefix = if (isSnapshot.value) "snapshots" else "releases"
-  Some(s3resolver.value(s"My ${prefix} S3 bucket", s3(s"tdr-$prefix-mgmt")))
-}
-
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommand("publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
 
 resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ scmInfo := Some(
 
 developers := List(
   Developer(
-    id    = "SP",
-    name  = "Sam Palmer",
-    email = "sam.palmer@nationalarchives.gov.uk",
+    id    = "tna-digital-archiving-jenkins",
+    name  = "TNA Digital Archiving",
+    email = "digitalpreservation@nationalarchives.gov.uk",
     url   = url("https://github.com/nationalarchives/tdr-generated-grapqhl")
   )
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("rocks.muki" % "sbt-graphql" % "0.13.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 resolvers += Resolver.jcenterRepo
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.188",
+  "version": "1.0.191",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nationalarchives/tdr-generated-graphql",
-      "version": "1.0.188",
+      "version": "1.0.191",
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "^2.6.2",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/tdr-generated-graphql",
-  "version": "1.0.188",
+  "version": "1.0.191",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.221-SNAPSHOT"
+ThisBuild / version := "0.0.223-SNAPSHOT"


### PR DESCRIPTION
Use sbt-release, sbt-sonatype and sbt-gpg plugins to publish to sonatype.
This will allow us to download the dependencies without needing authentication.
I've also moved this to github actions
