### PR TITLE
Change library type.

### DIFF
--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "noImplicitAny": true,
-    "module": "es6",
+    "module": "commonjs",
     "target": "es2016",
     "lib": ["es2017", "dom"],
     "allowSyntheticDefaultImports": true,

--- a/ts/webpack.config.js
+++ b/ts/webpack.config.js
@@ -16,8 +16,9 @@ module.exports = {
     extensions: [".ts", ".js"]
   },
   output: {
-    library: "tdr-generated-graphql",
-    libraryTarget: "commonjs-module",
+    library: {
+      type: "commonjs2"
+    },
     filename: "index.js",
     path: path.resolve(__dirname, ".")
   }


### PR DESCRIPTION
The way the library was being exported before wasn't working when run in
the browser by the front end.

This outputs something the front end can use. I've tested this locally
and it's working there.
