### PR TITLE
Upgrade @graphql-codegen-typescript

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@graphql-codegen/introspection": "^2.1.1",
-        "@graphql-codegen/typescript": "^2.4.7",
+        "@graphql-codegen/typescript": "^2.4.8",
         "@graphql-codegen/typescript-document-nodes": "^2.2.8",
         "@graphql-codegen/typescript-graphql-files-modules": "^2.1.1",
         "@graphql-codegen/typescript-operations": "^2.3.5",

--- a/ts/package.json
+++ b/ts/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/nationalarchives/tdr-generated-graphql#readme",
   "devDependencies": {
     "@graphql-codegen/introspection": "^2.1.1",
-    "@graphql-codegen/typescript": "^2.4.7",
+    "@graphql-codegen/typescript": "^2.4.8",
     "@graphql-codegen/typescript-document-nodes": "^2.2.8",
     "@graphql-codegen/typescript-graphql-files-modules": "^2.1.1",
     "@graphql-codegen/typescript-operations": "^2.3.5",


### PR DESCRIPTION
There's a security vulnerability against one of these libraries and this
is the only one with a new version.

I've checked the output from `npm run build` and nothing seems to have
happened to break the front end so I think we're ok.
