### PR TITLE
Add UpdateConsignmentSeriesId.graphql

### DIFF
--- a/src/main/graphql/GetConsignmentStatus.graphql
+++ b/src/main/graphql/GetConsignmentStatus.graphql
@@ -1,9 +1,14 @@
 query getConsignmentStatus($consignmentId: UUID!) {
     getConsignment(consignmentid: $consignmentId) {
+        series {
+            seriesid
+            code
+        }
         currentStatus {
-          transferAgreement
-          upload
-          confirmTransfer
+            series
+            transferAgreement
+            upload
+            confirmTransfer
         }
     }
 }

--- a/src/main/graphql/UpdateConsignmentSeriesId.graphql
+++ b/src/main/graphql/UpdateConsignmentSeriesId.graphql
@@ -1,0 +1,3 @@
+mutation updateConsignmentSeriesId($updateConsginmentSeriesIdInput: UpdateConsignmentSeriesIdInput!) {
+    updateConsignmentSeriesId(updateConsignmentSeriesId: $updateConsginmentSeriesIdInput)
+}


### PR DESCRIPTION
Added 'seriesId' and code to the getConsginmentStatus to prevent multiple db queries when returning the series the user had already selected in the frontend when populating the already completed dropdown.