### PR TITLE
Remove unneeded fields

### DIFF
--- a/src/main/graphql/GetClosureMetadata.graphql
+++ b/src/main/graphql/GetClosureMetadata.graphql
@@ -12,15 +12,7 @@ query closureMetadata($consignmentId: UUID!) {
         values {
             value
             dependencies {
-                name,
-                description,
-                fullName,
-                propertyType,
-                propertyGroup,
-                dataType,
-                editable,
-                multiValue,
-                defaultValue
+                name
             }
         }
     }


### PR DESCRIPTION
Since the dependencies are properties, they are already returned in this query. Therefore, all we need is
to do a lookup of the dependency 'name' in order to find all of the info, which would slightly reduce the
amount of data coming back and query size.