### PR TITLE
Query to retrieve file info for UI navigation

### DIFF
--- a/src/main/graphql/GetFilesForNavigation.graphql
+++ b/src/main/graphql/GetFilesForNavigation.graphql
@@ -1,0 +1,9 @@
+query getFilesForNavigation($consignmentId: UUID!) {
+    getConsignment(consignmentid: $consignmentId) {
+        files {
+            fileId
+            fileName,
+            fileType
+        }
+    }
+}


### PR DESCRIPTION
Temporary query to get file information necessary for basic navigation around a consignment's structure for editing additional metadata

This will be replaced with a specific query that returns a paginated response when pagination introduced in the navigation UI