### PR TITLE
TDR-2112 - Add graphql query to add a file status

### DIFF
--- a/src/main/graphql/AddFileStatus.graphql
+++ b/src/main/graphql/AddFileStatus.graphql
@@ -1,0 +1,7 @@
+mutation addFileStatus($addFileStatusInput: AddFileStatusInput!) {
+    addFileStatus(addFileStatusInput: $addFileStatusInput) {
+        fileId
+        statusType
+        statusValue
+    }
+}


### PR DESCRIPTION
`addFileStatus` graphql query to add a file status 'Success' or 'Failed' when user uploads files