### PR TITLE
Add originalFilePath

### DIFF
--- a/src/main/graphql/GetConsignmentExport.graphql
+++ b/src/main/graphql/GetConsignmentExport.graphql
@@ -16,6 +16,7 @@ query getConsignmentForExport($consignmentId: UUID!) {
             fileId
             fileType
             fileName
+            originalFilePath
             metadata {
                 clientSideFileSize,
                 clientSideLastModifiedDate,


### PR DESCRIPTION
This is the field that will hold the original version of a redacted
file. The changes to set this field have been made in the API. There
is still an open question about whether we store this somewhere or just
infer it each time but for now, this is working so this can go in.
