### PR TITLE
Add fields for download metadata page

### DIFF
--- a/src/main/graphql/AddBulkFileMetadata.graphql
+++ b/src/main/graphql/AddBulkFileMetadata.graphql
@@ -1,0 +1,9 @@
+mutation addBulkFileMetadata($updateBulkFileMetadataInput: UpdateBulkFileMetadataInput!) {
+  updateBulkFileMetadata(updateBulkFileMetadataInput: $updateBulkFileMetadataInput) {
+    fileIds
+    metadataProperties {
+      value
+      filePropertyName
+    }
+  }
+}

--- a/src/main/graphql/GetConsignmentFilesMetadata.graphql
+++ b/src/main/graphql/GetConsignmentFilesMetadata.graphql
@@ -2,6 +2,10 @@ query getConsignmentFilesMetadata($consignmentId: UUID!, $fileFiltersInput: File
     getConsignment(consignmentid: $consignmentId) {
         files (fileFiltersInput: $fileFiltersInput) {
             fileId
+            fileMetadata {
+                name
+                value
+            }
             metadata {
                 foiExemptionCode
                 closurePeriod

--- a/src/main/graphql/GetCustomMetadata.graphql
+++ b/src/main/graphql/GetCustomMetadata.graphql
@@ -17,5 +17,7 @@ query customMetadata($consignmentId: UUID!) {
             }
             uiOrdinal
         }
+        exportOrdinal
+        allowExport
     }
 }


### PR DESCRIPTION
This is the new fields which return the metadata as key value pairs and
the exportOrdinal and allowExport fields on the custom metadata.

I've also added the addBulkFileMetadata mutation. This is needed for the e2e tests changes for downloading the metadata
but we'll need it for other things soon enough.
