### PR TITLE
Temporarily remove 'titlePublic' from query

### DIFF
--- a/src/main/graphql/GetConsignmentFilesMetadata.graphql
+++ b/src/main/graphql/GetConsignmentFilesMetadata.graphql
@@ -11,7 +11,6 @@ query getConsignmentFilesMetadata($consignmentId: UUID!, $fileFiltersInput: File
                 closurePeriod
                 closureStartDate
                 foiExemptionAsserted
-                titlePublic
             }
         }
         consignmentReference


### PR DESCRIPTION
We are going to [rename this in the consignment API](https://github.com/nationalarchives/tdr-consignment-api/pull/441) so I think we need to not request 'titlePublic' in the query, in order to prevent it throwing an error.