### PR TITLE
Remove old metadata from export.

### DIFF
--- a/src/main/graphql/GetConsignmentExport.graphql
+++ b/src/main/graphql/GetConsignmentExport.graphql
@@ -17,16 +17,9 @@ query getConsignmentForExport($consignmentId: UUID!) {
             fileType
             fileName
             originalFilePath
-            metadata {
-                clientSideFileSize,
-                clientSideLastModifiedDate,
-                clientSideOriginalFilePath,
-                foiExemptionCode,
-                heldBy,
-                language,
-                legalStatus,
-                rightsCopyright,
-                sha256ClientSideChecksum
+            fileMetadata {
+                name
+                value
             }
             ffidMetadata {
                 software


### PR DESCRIPTION
The export is being refactored to use the new key value metadata so the old style one can be removed from the query.
The export should be the only process using this query.
