### PR TITLE
Add 'server' statuses to 'getConsignments' query

### DIFF
--- a/src/main/graphql/GetConsignments.graphql
+++ b/src/main/graphql/GetConsignments.graphql
@@ -12,6 +12,9 @@ query getConsignments($limit: Int!, $currentCursor: String, $consignmentFiltersI
                     transferAgreement
                     upload
                     clientChecks
+                    serverAntivirus
+                    serverChecksum
+                    serverFFID
                     confirmTransfer
                     export
                 }


### PR DESCRIPTION
'View transfers' feature uses 'getConsignments' query