### PR TITLE
TDR- 3064 remove deprecated method addFileMetadata in class FileMetadataService

### DIFF
--- a/src/main/graphql/AddFileMetadata.graphql
+++ b/src/main/graphql/AddFileMetadata.graphql
@@ -1,5 +1,6 @@
 mutation addFileMetadata($addFileMetadataWithFileIdInput: AddFileMetadataWithFileIdInputValues!) {
     addFileMetadata(addFileMetadataWithFileIdInput: $addFileMetadataWithFileIdInput) {
+        filePropertyName,
         fileId,
         value
     }

--- a/src/main/graphql/AddFileMetadata.graphql
+++ b/src/main/graphql/AddFileMetadata.graphql
@@ -1,7 +1,0 @@
-mutation addFileMetadata($addFileMetadataWithFileIdInput: AddFileMetadataWithFileIdInputValues!) {
-    addFileMetadata(addFileMetadataWithFileIdInput: $addFileMetadataWithFileIdInput) {
-        filePropertyName,
-        fileId,
-        value
-    }
-}


### PR DESCRIPTION
[TDR-3064](https://national-archives.atlassian.net/browse/TDR-3064?atlOrigin=eyJpIjoiODZjYWRhN2IwZWM0NDEzNmIxMjRjZWEyY2ZiYTUxMjUiLCJwIjoiaiJ9)

- [x] Update GraphQL entry

[TDR-3064]: https://national-archives.atlassian.net/browse/TDR-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ