### PR TITLE
TDR-3063 remove FFIDMetdaService

### DIFF
--- a/src/main/graphql/AddFFIDMetadata.graphql
+++ b/src/main/graphql/AddFFIDMetadata.graphql
@@ -1,5 +1,0 @@
-mutation addFFIDMetadata($addFFIDMetadataInput: FFIDMetadataInputValues!) {
-    addFFIDMetadata(addFFIDMetadataInput: $addFFIDMetadataInput) {
-        fileId
-    }
-}


### PR DESCRIPTION
- [x] Update GraphQL entry 

May have got the wrong end of the stick here, but I think this mutation is associated with the altered entry in the [associated consignment API PR](https://github.com/nationalarchives/tdr-consignment-api/pull/604/files)

[Ticket found here ](https://national-archives.atlassian.net/browse/TDR-3063?atlOrigin=eyJpIjoiYjdlZjdlMDk0NmI4NDdiNGEwODc4MWY5ZTIzYTJlN2MiLCJwIjoiaiJ9)