### PR TITLE
Add new `propertyProtected` to `CustomMetadata` query

### DIFF
--- a/src/main/graphql/GetCustomMetadata.graphql
+++ b/src/main/graphql/GetCustomMetadata.graphql
@@ -5,6 +5,7 @@ query customMetadata($consignmentId: UUID!) {
         fullName,
         propertyType,
         propertyGroup,
+        propertyProtected,
         dataType,
         editable,
         multiValue,


### PR DESCRIPTION
New `propertyProtected` boolean if metadata propertie is protected i.e. UUID
requires https://github.com/nationalarchives/tdr-consignment-api/pull/849