### PR TITLE
Return consignment reference in response

### DIFF
--- a/src/main/graphql/AddConsignment.graphql
+++ b/src/main/graphql/AddConsignment.graphql
@@ -2,5 +2,6 @@ mutation addConsignment($addConsignmentInput: AddConsignmentInput!) {
     addConsignment(addConsignmentInput: $addConsignmentInput) {
         consignmentid
         seriesid
+        consignmentReference
     }
 }


### PR DESCRIPTION
SharePoint application requires the consignment reference of the consignment that has been created for UI purposes.

Return the 'consignmentReference' field in the 'AddConsignment' mutation response.

This will be a breaking change in unit tests for other services