### PR TITLE
added package-lock.json to files that indicate ts-only tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
           fi
           
           changedFiles=$(git diff --name-only --diff-filter=d "$firstCommit" "$lastCommit")
-          if echo "$changedFiles" | grep -q "ts/package.json"; then
+          if echo "$changedFiles" | grep -qE "ts/package.json|ts/package-lock.json"; then
              echo "package-json-modified=true" >> $GITHUB_OUTPUT
           else
             echo "package-json-modified=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Tag changes for package-lock.json file. Merge conflicts for this file might be done manually and do not want to remove tag 