### PR TITLE
TDRD-795 - remove `GetAllDescendants.graphql`

### DIFF
--- a/src/main/graphql/GetAllDescendants.graphql
+++ b/src/main/graphql/GetAllDescendants.graphql
@@ -1,6 +1,0 @@
-query getAllDescendantIds($allDescendantsInput: AllDescendantsInput!) {
-    allDescendants(allDescendantsInput: $allDescendantsInput) {
-        fileId
-        fileType
-    }
-}


### PR DESCRIPTION
This was used to display the tree view of files in the UI which has been removed from the frontend.