### PR TITLE
Delete `DeleteFileMetadata.graphql`

### DIFF
--- a/src/main/graphql/DeleteFileMetadata.graphql
+++ b/src/main/graphql/DeleteFileMetadata.graphql
@@ -1,6 +1,0 @@
-mutation deleteFileMetadata($deleteFileMetadataInput: DeleteFileMetadataInput!) {
-    deleteFileMetadata(deleteFileMetadataInput: $deleteFileMetadataInput)  {
-        fileIds
-        filePropertyNames
-    }
-}


### PR DESCRIPTION
This was only used in the frontend UI but has since been removed.