### PR TITLE
Delete `AddBulkFileMetadata.graphql`

### DIFF
--- a/src/main/graphql/AddBulkFileMetadata.graphql
+++ b/src/main/graphql/AddBulkFileMetadata.graphql
@@ -1,9 +1,0 @@
-mutation addBulkFileMetadata($updateBulkFileMetadataInput: UpdateBulkFileMetadataInput!) {
-  updateBulkFileMetadata(updateBulkFileMetadataInput: $updateBulkFileMetadataInput) {
-    fileIds
-    metadataProperties {
-      value
-      filePropertyName
-    }
-  }
-}


### PR DESCRIPTION
Was used in the old additional metadata