### PR TITLE
Require transferring body name for user notifications

### DIFF
--- a/src/main/graphql/GetConsignment.graphql
+++ b/src/main/graphql/GetConsignment.graphql
@@ -6,6 +6,7 @@ query getConsignment($consignmentId: UUID!) {
         consignmentReference
         parentFolderId
         clientSideDraftMetadataFileName
+        transferringBodyName
         consignmentStatuses {
             statusType
             value


### PR DESCRIPTION
Users receive an email when a SharePoint upload has completed processing

The email needs to include the transferring body name