### PR TITLE
Fix npm build issue after upgrading GraphQL Codegen plugins to v6

### DIFF
--- a/ts/codegen.yml
+++ b/ts/codegen.yml
@@ -10,7 +10,6 @@ generates:
       - typescript-graphql-files-modules
   src/index.ts:
     plugins:
-      - "typescript"
       - "typescript-operations"
       - "typescript-document-nodes"
   ./graphql.schema.json:

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
+    "rootDir": "./src",
     "noImplicitAny": true,
     "module": "commonjs",
     "target": "es2016",
@@ -11,6 +12,7 @@
     "declaration": true,
     "declarationDir": ".",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "strict": true
   },
   "include": ["src/*"],

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "./dist/",
     "rootDir": "./src",
     "noImplicitAny": true,
-    "module": "commonjs",
+    "module": "nodenext",
     "target": "es2016",
     "lib": ["es2017", "dom"],
     "allowSyntheticDefaultImports": true,
@@ -12,8 +12,7 @@
     "sourceMap": true,
     "declaration": true,
     "declarationDir": ".",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "nodenext",
     "strict": true
   },
   "include": ["src/*"],

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/",
-    "rootDir": "./src",
     "noImplicitAny": true,
     "module": "nodenext",
     "target": "es2016",


### PR DESCRIPTION
- Remove `typescript` plugin from src/index.ts
- In codegen v6, `typescript-operations` now re-declares all input/enum types instead of relying on the `typescript` plugin
- nodenext is one of the modern, non-deprecated resolution strategies, so the TS5107 deprecation goes away at its source — it won't break in TS 7.0.