### PR TITLE
Fix npm codegen issue

### DIFF
--- a/ts/codegen.yml
+++ b/ts/codegen.yml
@@ -8,8 +8,15 @@ generates:
   src/index.d.ts:
     plugins:
       - typescript-graphql-files-modules
-  src/index.ts:
+  src/schema-types.ts:
     plugins:
+      - "typescript"
+  src/index.ts:
+    config:
+      importSchemaTypesFrom: "src/schema-types"
+    plugins:
+      - add:
+          content: "export * from './schema-types';"
       - "typescript-operations"
       - "typescript-document-nodes"
   ./graphql.schema.json:

--- a/ts/codegen.yml
+++ b/ts/codegen.yml
@@ -4,6 +4,9 @@ documents: "../src/main/graphql/*.graphql"
 config:
   scalars:
     Long: number
+    UUID: string
+    LocalDateTime: string
+    ZonedDateTime: string
 generates:
   src/index.d.ts:
     plugins:

--- a/ts/package.json
+++ b/ts/package.json
@@ -20,6 +20,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "schema-types.d.ts",
     "package.json"
   ],
   "homepage": "https://github.com/nationalarchives/tdr-generated-graphql#readme",


### PR DESCRIPTION
- Add custom scalars. In GraphQL Codegen v6, unmapped custom scalars default to unknown
- Add 'typescript' plugin to generate schema types (Consignment, FileStatus etc.)